### PR TITLE
Fixes and AMSoftmax support in pytorchcv wrapper

### DIFF
--- a/torchreid/engine/engine.py
+++ b/torchreid/engine/engine.py
@@ -94,22 +94,21 @@ class Engine:
         names = self.get_model_names()
 
         for name in names:
-            ckpt_name = osp.join(save_dir, name)
-            save_checkpoint(
-                {
-                    'state_dict': self.models[name].state_dict(),
-                    'epoch': epoch + 1,
-                    'optimizer': self.optims[name].state_dict(),
-                    'scheduler': self.scheds[name].state_dict(),
-                    'num_classes': self.datamanager.num_train_pids
-                },
-                ckpt_name,
-                is_best=is_best
-            )
+            ckpt_path = save_checkpoint(
+                            {
+                                'state_dict': self.models[name].state_dict(),
+                                'epoch': epoch + 1,
+                                'optimizer': self.optims[name].state_dict(),
+                                'scheduler': self.scheds[name].state_dict(),
+                                'num_classes': self.datamanager.num_train_pids
+                            },
+                            osp.join(save_dir, name),
+                            is_best=is_best
+                        )
             latest_name = osp.join(save_dir, 'latest.pth')
             if osp.lexists(latest_name):
                 os.remove(latest_name)
-            os.symlink(ckpt_name, latest_name)
+            os.symlink(ckpt_path, latest_name)
 
     def set_model_mode(self, mode='train', names=None):
         assert mode in ['train', 'eval', 'test']

--- a/torchreid/engine/image/am_softmax.py
+++ b/torchreid/engine/image/am_softmax.py
@@ -206,9 +206,14 @@ class ImageAMSoftmaxEngine(Engine):
 
             total_loss += mutual_loss / float(num_mutual_losses)
 
-        total_loss.backward()
+        total_loss.backward(retain_graph=self.enable_metric_losses)
 
         for model_name in model_names:
+            for trg_id in range(self.num_targets):
+                if self.enable_metric_losses:
+                    ml_loss_module = self.ml_losses[trg_id][model_name]
+                    ml_loss_module.end_iteration()
+
             self.optims[model_name].step()
 
         loss_summary['loss'] = total_loss.item()
@@ -252,7 +257,7 @@ class ImageAMSoftmaxEngine(Engine):
 
                 ml_loss_module.init_iteration()
                 ml_loss, ml_loss_summary = ml_loss_module(embd, trg_logits, trg_obj_ids, n_iter)
-                ml_loss_module.end_iteration()
+                #ml_loss_module.end_iteration()
 
                 loss_summary['ml_{}/{}'.format(trg_id, model_name)] = ml_loss.item()
                 loss_summary.update(ml_loss_summary)

--- a/torchreid/engine/image/am_softmax.py
+++ b/torchreid/engine/image/am_softmax.py
@@ -206,13 +206,13 @@ class ImageAMSoftmaxEngine(Engine):
 
             total_loss += mutual_loss / float(num_mutual_losses)
 
-        total_loss.backward(retain_graph=self.enable_metric_losses)
+        total_loss.backward()
 
         for model_name in model_names:
             for trg_id in range(self.num_targets):
                 if self.enable_metric_losses:
                     ml_loss_module = self.ml_losses[trg_id][model_name]
-                    ml_loss_module.end_iteration()
+                    ml_loss_module.end_iteration(do_backward=False)
 
             self.optims[model_name].step()
 
@@ -257,7 +257,6 @@ class ImageAMSoftmaxEngine(Engine):
 
                 ml_loss_module.init_iteration()
                 ml_loss, ml_loss_summary = ml_loss_module(embd, trg_logits, trg_obj_ids, n_iter)
-                #ml_loss_module.end_iteration()
 
                 loss_summary['ml_{}/{}'.format(trg_id, model_name)] = ml_loss.item()
                 loss_summary.update(ml_loss_summary)

--- a/torchreid/losses/am_softmax.py
+++ b/torchreid/losses/am_softmax.py
@@ -38,7 +38,7 @@ class AngleSimpleLinear(nn.Module):
         self.weight.data.normal_().renorm_(2, 1, 1e-5).mul_(1e5)
 
     def forward(self, x):
-        cos_theta = F.normalize(x, dim=1).mm(F.normalize(self.weight, p=2, dim=0))
+        cos_theta = F.normalize(x.view(x.shape[0], -1), dim=1).mm(F.normalize(self.weight, p=2, dim=0))
         return cos_theta.clamp(-1, 1)
 
     def get_centers(self):

--- a/torchreid/losses/metric.py
+++ b/torchreid/losses/metric.py
@@ -298,10 +298,11 @@ class MetricLosses:
         if self.loss_balancing:
             self.balancing_optimizer.zero_grad()
 
-    def end_iteration(self):
+    def end_iteration(self, do_backward=True):
         """Finalizes a training iteration"""
 
-        self.last_loss_value.backward()
+        if do_backward:
+            self.last_loss_value.backward()
 
         if self.center_coeff > 0.:
             self.center_optimizer.step()

--- a/torchreid/losses/metric.py
+++ b/torchreid/losses/metric.py
@@ -301,7 +301,7 @@ class MetricLosses:
     def end_iteration(self):
         """Finalizes a training iteration"""
 
-        self.last_loss_value.backward(retain_graph=True)
+        self.last_loss_value.backward()
 
         if self.center_coeff > 0.:
             self.center_optimizer.step()

--- a/torchreid/utils/torchtools.py
+++ b/torchreid/utils/torchtools.py
@@ -56,6 +56,7 @@ def save_checkpoint(
     print('Checkpoint saved to "{}"'.format(fpath))
     if is_best:
         shutil.copy(fpath, osp.join(osp.dirname(fpath), 'model-best.pth.tar'))
+    return fpath
 
 
 def load_checkpoint(fpath):


### PR DESCRIPTION
@evgeny-izutov please take a look at the changes in metric learning losses. Seems like now pytorch disables making optimizer.step() between two related backwards, so I had to move the call of end_iteration().