### PR TITLE
Add a more flexible handling of custom datasets

### DIFF
--- a/scripts/default_config.py
+++ b/scripts/default_config.py
@@ -59,9 +59,12 @@ def get_default_config():
     cfg.cuhk03.labeled_images = False  # use labeled images, if False, use detected images
     cfg.cuhk03.classic_split = False  # use classic split by Li et al. CVPR14
     cfg.cuhk03.use_metric_cuhk03 = False  # use cuhk03's metric for evaluation
-    cfg.classification = CN()
-    cfg.classification.data_dir = 'cl'
-    cfg.classification.version = ''
+
+    # custom_datasets
+    cfg.custom_datasets = CN() # this node contains information about custom classification datasets
+    cfg.custom_datasets.roots = [] # a list of root folders in case of ImagesFolder fromat or list of annotation files with paths relative to the list's parent folder
+    cfg.custom_datasets.types = [] # a list of types (classification or classification_image_folder)
+    cfg.custom_datasets.names = [] # aliases for custom datasets that can be used in the data section. Should be unique
 
     # sampler
     cfg.sampler = CN()
@@ -357,10 +360,11 @@ def imagedata_kwargs(cfg):
         'cuhk03_labeled': cfg.cuhk03.labeled_images,
         'cuhk03_classic_split': cfg.cuhk03.classic_split,
         'market1501_500k': cfg.market1501.use_500k_distractors,
-        'cl_data_dir': cfg.classification.data_dir,
-        'cl_version': cfg.classification.version,
         'apply_masks_to_test': cfg.test.apply_masks,
         'min_samples_per_id': cfg.data.min_samples_per_id,
+        'custom_dataset_names': cfg.custom_datasets.names,
+        'custom_dataset_roots': cfg.custom_datasets.roots,
+        'custom_dataset_types': cfg.custom_datasets.types,
     }
 
 

--- a/tools/main.py
+++ b/tools/main.py
@@ -32,6 +32,12 @@ def reset_config(cfg, args):
         cfg.data.sources = args.sources
     if args.targets:
         cfg.data.targets = args.targets
+    if args.custom_roots:
+        cfg.custom_datasets.roots = args.custom_roots
+    if args.custom_types:
+        cfg.custom_datasets.types = args.custom_types
+    if args.custom_names:
+        cfg.custom_datasets.names = args.custom_names
 
 
 def build_auxiliary_model(config_file, num_classes, use_gpu, device_ids=None, weights=None):
@@ -71,6 +77,12 @@ def main():
                         help='target datasets (delimited by space)')
     parser.add_argument('--root', type=str, default='',
                         help='path to data root')
+    parser.add_argument('--custom-roots', type=str, nargs='+',
+                        help='types or paths to annotation of custom datasets (delimited by space)')
+    parser.add_argument('--custom-types', type=str, nargs='+',
+                        help='path of custom datasets (delimited by space)')
+    parser.add_argument('--custom-names', type=str, nargs='+',
+                        help='names of custom datasets (delimited by space)')
     parser.add_argument('--gpu-num', type=int, default=1,
                         help='Number of GPUs for training. 0 is for CPU mode')
     parser.add_argument('opts', default=None, nargs=argparse.REMAINDER,

--- a/torchreid/data/datamanager.py
+++ b/torchreid/data/datamanager.py
@@ -182,8 +182,9 @@ class ImageDataManager(DataManager):
         cuhk03_labeled=False,
         cuhk03_classic_split=False,
         market1501_500k=False,
-        cl_data_dir='cl',
-        cl_version='',
+        custom_dataset_names=[''],
+        custom_dataset_roots=[''],
+        custom_dataset_types=[''],
         apply_masks_to_test=False,
         min_samples_per_id=0,
         num_sampled_packages=1
@@ -218,8 +219,9 @@ class ImageDataManager(DataManager):
                 cuhk03_labeled=cuhk03_labeled,
                 cuhk03_classic_split=cuhk03_classic_split,
                 market1501_500k=market1501_500k,
-                cl_data_dir=cl_data_dir,
-                cl_version=cl_version,
+                custom_dataset_names=custom_dataset_names,
+                custom_dataset_roots=custom_dataset_roots,
+                custom_dataset_types=custom_dataset_types,
                 min_id_samples=min_samples_per_id,
                 num_sampled_packages=num_sampled_packages
             ))
@@ -280,8 +282,9 @@ class ImageDataManager(DataManager):
                     cuhk03_labeled=cuhk03_labeled,
                     cuhk03_classic_split=cuhk03_classic_split,
                     market1501_500k=market1501_500k,
-                    cl_data_dir=cl_data_dir,
-                    cl_version=cl_version,
+                    custom_dataset_names=custom_dataset_names,
+                    custom_dataset_roots=custom_dataset_roots,
+                    custom_dataset_types=custom_dataset_types,
                 )
                 self.test_loader[name]['query'] = torch.utils.data.DataLoader(
                     query_dataset,
@@ -304,8 +307,9 @@ class ImageDataManager(DataManager):
                     cuhk03_labeled=cuhk03_labeled,
                     cuhk03_classic_split=cuhk03_classic_split,
                     market1501_500k=market1501_500k,
-                    cl_data_dir=cl_data_dir,
-                    cl_version=cl_version,
+                    custom_dataset_names=custom_dataset_names,
+                    custom_dataset_roots=custom_dataset_roots,
+                    custom_dataset_types=custom_dataset_types,
                 )
                 self.test_loader[name]['gallery'] = torch.utils.data.DataLoader(
                     gallery_dataset,

--- a/torchreid/data/datasets/__init__.py
+++ b/torchreid/data/datasets/__init__.py
@@ -56,14 +56,26 @@ __video_datasets = {
 }
 
 
-def init_image_dataset(name, **kwargs):
+def init_image_dataset(name, custom_dataset_names=[''],
+                       custom_dataset_roots=[''],
+                       custom_dataset_types=[''], **kwargs):
     """Initializes an image dataset."""
+
+    #handle also custom datasets
     avai_datasets = list(__image_datasets.keys())
-    if name not in avai_datasets:
+    assert len(name) > 0
+    if name not in avai_datasets and name not in custom_dataset_names:
         raise ValueError(
             'Invalid dataset name. Received "{}", '
-            'but expected to be one of {}'.format(name, avai_datasets)
+            'but expected to be one of {} {}'.format(name, avai_datasets, custom_dataset_names)
         )
+    if name in custom_dataset_names:
+        assert len(custom_dataset_names) == len(custom_dataset_types)
+        assert len(custom_dataset_names) == len(custom_dataset_roots)
+        i = custom_dataset_names.index(name)
+        kwargs['root'] = custom_dataset_roots[i]
+        return __image_datasets[custom_dataset_types[i]](**kwargs)
+
     return __image_datasets[name](**kwargs)
 
 

--- a/torchreid/data/datasets/__init__.py
+++ b/torchreid/data/datasets/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import
 
+from copy import copy
+
 from .image import (
     GRID, PRID, CUHK01, CUHK02, CUHK03, MSMT17, VIPeR, SenseReID, Market1501, DukeMTMCreID, iLIDS,
     VRIC, VeRi, CompCars, VMMRdb, CityFlow, Vehicle1M, UniverseModels, VeRiWild,
@@ -73,8 +75,9 @@ def init_image_dataset(name, custom_dataset_names=[''],
         assert len(custom_dataset_names) == len(custom_dataset_types)
         assert len(custom_dataset_names) == len(custom_dataset_roots)
         i = custom_dataset_names.index(name)
-        kwargs['root'] = custom_dataset_roots[i]
-        return __image_datasets[custom_dataset_types[i]](**kwargs)
+        new_kwargs = copy(kwargs)
+        new_kwargs['root'] = custom_dataset_roots[i]
+        return __image_datasets[custom_dataset_types[i]](**new_kwargs)
 
     return __image_datasets[name](**kwargs)
 

--- a/torchreid/engine/engine.py
+++ b/torchreid/engine/engine.py
@@ -360,7 +360,7 @@ class Engine:
                     self._evaluate_classification(
                         model=model,
                         epoch=epoch,
-                        data_loader=self.test_loader[dataset_name]['gallery'],
+                        data_loader=self.test_loader[dataset_name]['query'],
                         model_name=model_name,
                         dataset_name=dataset_name,
                         ranks=ranks


### PR DESCRIPTION
To align with templates, subsets of classification datasets are decoupled now.
Examples of configs:
```
custom_datasets:
  roots: ['/mnt/data/datasets/imagenet/train', '/mnt/data/datasets/imagenet/val']
  types: ['classification_image_folder', 'classification_image_folder']
  names: ['imagenet_train', 'imagenet_val']
data:
  root: './'
  type: 'image'
  sources: ['imagenet_train']
  targets: ['imagenet_val']
...
```
```
custom_datasets:
  roots: ['/mnt/data/datasets/flowers/train.txt', '/mnt/data/datasets/flowers/val.txt']
  types: ['classification', 'classification']
  names: ['flowers_train', 'flowers_val']
data:
  root: './'
  type: 'image'
  sources: ['flowers_train']
  targets: ['flowers_val']
...
```
