### PR TITLE
Fix compressed model isn't moved to gpu before wrapping

### DIFF
--- a/tools/main.py
+++ b/tools/main.py
@@ -81,6 +81,9 @@ def main():
     aux_lr = cfg.train.lr # placeholder, needed for aux models, may be filled by nncf part below
     if is_nncf_used:
         print('Begin making NNCF changes in model')
+        if cfg.use_gpu:
+            model.cuda()
+
         compression_ctrl, model, cfg, aux_lr, nncf_metainfo = \
             make_nncf_changes_in_training(model, cfg,
                                           args.classes,


### PR DESCRIPTION
It has been found that model isn't moved to GPU before compression. This leads to dramatic NNCF initialization time rise (8-12h) due to CPU samples inference.