### PR TITLE
Proposed export fix

### DIFF
--- a/tools/convert_to_onnx.py
+++ b/tools/convert_to_onnx.py
@@ -16,6 +16,7 @@
 
 import argparse
 import os
+import warnings
 
 import torch
 
@@ -100,6 +101,9 @@ def main():
     model = build_model(**model_kwargs(cfg, num_classes))
     if cfg.model.load_weights:
         load_pretrained_weights(model, cfg.model.load_weights)
+    else:
+        warnings.warn("No weights are passed through 'load_weights' parameter! "
+              "The model will be converted with random or pretrained weights", category=RuntimeWarning)
     if 'tresnet' in cfg.model.name:
         patch_InplaceAbn_forward()
     if is_nncf_used:

--- a/tools/convert_to_onnx.py
+++ b/tools/convert_to_onnx.py
@@ -31,7 +31,7 @@ from torchreid.integration.nncf.compression_script_utils import (make_nncf_chang
 
 def parse_num_classes(source_datasets, classification=False, num_classes=None, snap_path=None):
     if classification:
-        if snap_path is not None:
+        if snap_path:
             chkpt = load_checkpoint(snap_path)
             num_classes_from_snap = chkpt['num_classes'] if 'num_classes' in chkpt else None
 
@@ -98,7 +98,8 @@ def main():
                                     num_classes=args.num_classes, 
                                     snap_path=cfg.model.load_weights)
     model = build_model(**model_kwargs(cfg, num_classes))
-    load_pretrained_weights(model, cfg.model.load_weights)
+    if cfg.model.load_weights:
+        load_pretrained_weights(model, cfg.model.load_weights)
     if 'tresnet' in cfg.model.name:
         patch_InplaceAbn_forward()
     if is_nncf_used:

--- a/torchreid/apis/export.py
+++ b/torchreid/apis/export.py
@@ -77,7 +77,7 @@ def export_onnx(model, cfg, output_file_path='model', disable_dyn_axes=True,
     return output_file_path
 
 
-def export_ir(onnx_model_path, norm_mean=[0,0,0], norm_std=[1,1,1], input_shape=[1, 3, 224, 224],
+def export_ir(onnx_model_path, norm_mean=[0,0,0], norm_std=[1,1,1], input_shape=None,
                 optimized_model_dir='./ir_model', data_type='FP32'):
     def get_mo_cmd():
         for mo_cmd in ('mo', 'mo.py'):

--- a/torchreid/apis/export.py
+++ b/torchreid/apis/export.py
@@ -98,7 +98,8 @@ def export_ir(onnx_model_path, norm_mean=[0,0,0], norm_std=[1,1,1], input_shape=
                     f'--scale_values="{scale_values}" ' \
                     f'--output_dir="{optimized_model_dir}" ' \
                     f'--data_type {data_type} ' \
-                    f'--input_shape "{input_shape}" ' \
                     '--reverse_input_channels'
+    if input_shape:
+        command_line += f' --input_shape "{input_shape}" '
 
     run(command_line, shell=True, check=True)

--- a/torchreid/apis/export.py
+++ b/torchreid/apis/export.py
@@ -77,7 +77,8 @@ def export_onnx(model, cfg, output_file_path='model', disable_dyn_axes=True,
     return output_file_path
 
 
-def export_ir(onnx_model_path, norm_mean=[0,0,0], norm_std=[1,1,1], optimized_model_dir='./ir_model', data_type='FP32'):
+def export_ir(onnx_model_path, norm_mean=[0,0,0], norm_std=[1,1,1], input_shape=[1, 3, 224, 224],
+                optimized_model_dir='./ir_model', data_type='FP32'):
     def get_mo_cmd():
         for mo_cmd in ('mo', 'mo.py'):
             try:
@@ -97,6 +98,7 @@ def export_ir(onnx_model_path, norm_mean=[0,0,0], norm_std=[1,1,1], optimized_mo
                     f'--scale_values="{scale_values}" ' \
                     f'--output_dir="{optimized_model_dir}" ' \
                     f'--data_type {data_type} ' \
+                    f'--input_shape "{input_shape}" ' \
                     '--reverse_input_channels'
 
     run(command_line, shell=True, check=True)


### PR DESCRIPTION
Please, consider adding `input_shape` parameter to export IR API for the SC task.
This is for extra safety in case of MO isn't able to inherit proper shapes from the ONNX format.
That was my problem why, models weren't converted to IR.

Also, I propose to use always key arguments explicitly in function call  for safety and readability