### PR TITLE
Fix annotation scene assignment in dataset item

### DIFF
--- a/torchreid/integration/sc/openvino_task.py
+++ b/torchreid/integration/sc/openvino_task.py
@@ -188,7 +188,8 @@ class OpenVINOClassificationTask(IInferenceTask, IEvaluationTask, IOptimizationT
             update_progress_callback = inference_parameters.update_progress
         dataset_size = len(dataset)
         for i, dataset_item in enumerate(dataset, 1):
-            dataset_item.annotation_scene = self.inferencer.predict(dataset_item.numpy)
+            predicted_scene = self.inferencer.predict(dataset_item.numpy)
+            dataset_item.append_annotations(predicted_scene.annotations)
             dataset_item.append_labels(dataset_item.annotation_scene.annotations[0].get_labels())
             update_progress_callback(int(i / dataset_size * 100))
         return dataset


### PR DESCRIPTION
Assignments to `DatasetItem.annotation_scene` should be avoided in task implementations and forbidden at the SDK level (WIP).