### PR TITLE
Add missing hpo_config.yaml files

### DIFF
--- a/configs/ote_custom_classification/mobilenet_v3_large_075/hpo_config.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_large_075/hpo_config.yaml
@@ -1,0 +1,16 @@
+metric: mAP
+search_algorithm: smbo
+early_stop: median_stop
+hp_space:
+  learning_parameters.learning_rate:
+    param_type: quniform
+    range: 
+      - 0.005
+      - 0.029
+      - 0.001
+  learning_parameters.batch_size:
+    param_type: qloguniform
+    range: 
+      - 8
+      - 64
+      - 2

--- a/configs/ote_custom_classification/mobilenet_v3_small/hpo_config.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_small/hpo_config.yaml
@@ -1,0 +1,16 @@
+metric: mAP
+search_algorithm: smbo
+early_stop: median_stop
+hp_space:
+  learning_parameters.learning_rate:
+    param_type: quniform
+    range: 
+      - 0.005
+      - 0.029
+      - 0.001
+  learning_parameters.batch_size:
+    param_type: qloguniform
+    range: 
+      - 8
+      - 64
+      - 2

--- a/torchreid/integration/sc/train_task.py
+++ b/torchreid/integration/sc/train_task.py
@@ -78,6 +78,9 @@ class OTEClassificationTrainingTask(OTEClassificationInferenceTask, ITrainingTas
 
         return output
 
+    def set_lr_finder_enable_flag(self, enable_flag: bool):
+        self._cfg.lr_finer.enable = enable_flag
+
     def train(self, dataset: DatasetEntity, output_model: ModelEntity,
               train_parameters: Optional[TrainParameters] = None):
         """ Trains a model on a dataset """

--- a/torchreid/integration/sc/train_task.py
+++ b/torchreid/integration/sc/train_task.py
@@ -78,9 +78,6 @@ class OTEClassificationTrainingTask(OTEClassificationInferenceTask, ITrainingTas
 
         return output
 
-    def set_lr_finder_enable_flag(self, enable_flag: bool):
-        self._cfg.lr_finder.enable = enable_flag
-
     def train(self, dataset: DatasetEntity, output_model: ModelEntity,
               train_parameters: Optional[TrainParameters] = None):
         """ Trains a model on a dataset """

--- a/torchreid/integration/sc/train_task.py
+++ b/torchreid/integration/sc/train_task.py
@@ -79,7 +79,7 @@ class OTEClassificationTrainingTask(OTEClassificationInferenceTask, ITrainingTas
         return output
 
     def set_lr_finder_enable_flag(self, enable_flag: bool):
-        self._cfg.lr_finer.enable = enable_flag
+        self._cfg.lr_finder.enable = enable_flag
 
     def train(self, dataset: DatasetEntity, output_model: ModelEntity,
               train_parameters: Optional[TrainParameters] = None):


### PR DESCRIPTION
### Add hpo_config.yaml file to mobilenet_v3_large_075 and mobilenet_v3_small.
When adding this file to d-o-r, only efficientnet_b0 and mobilenet_v3_large_1 in ote_custom_classification have template.yaml.
But that's not case now, so we add hpo_config.yaml to remaining two model directories.