### PR TITLE
Data type for score in update_progress_callback is converted to float.

### DIFF
--- a/torchreid/integration/sc/utils.py
+++ b/torchreid/integration/sc/utils.py
@@ -269,14 +269,13 @@ class TrainingProgressCallback(TimeMonitorCallback):
 
     def on_epoch_end(self, epoch, logs=None):
         self.past_epoch_duration.append(time.time() - self.start_epoch_time)
-        self.__calculate_average_epoch()
-        self.update_progress_callback(self.get_progress(), score=logs)
-
-    def __calculate_average_epoch(self):
-        if len(self.past_epoch_duration) > self.epoch_history:
-            self.past_epoch_duration.remove(self.past_epoch_duration[0])
-        self.average_epoch = sum(self.past_epoch_duration) / len(
-            self.past_epoch_duration)
+        self._calculate_average_epoch()
+        score = None
+        if isinstance(logs, numpy.float64):
+            score = logs.item()
+        elif isinstance(logs, int):
+            score = float(logs)
+        self.update_progress_callback(self.get_progress(), score=score)
 
 
 class InferenceProgressCallback(TimeMonitorCallback):

--- a/torchreid/integration/sc/utils.py
+++ b/torchreid/integration/sc/utils.py
@@ -270,12 +270,7 @@ class TrainingProgressCallback(TimeMonitorCallback):
     def on_epoch_end(self, epoch, logs=None):
         self.past_epoch_duration.append(time.time() - self.start_epoch_time)
         self._calculate_average_epoch()
-        score = None
-        if isinstance(logs, numpy.float64):
-            score = logs.item()
-        elif isinstance(logs, int):
-            score = float(logs)
-        self.update_progress_callback(self.get_progress(), score=score)
+        self.update_progress_callback(self.get_progress(), score=float(logs))
 
 
 class InferenceProgressCallback(TimeMonitorCallback):


### PR DESCRIPTION
1. Data type for score in update_progress_callback is declared as float, and this PR converts data type for score to float.

2. Unnecessary function __calculate_average_epoch() is removed, and it is replaced with _calculate_average_epoch() in ote_sdk.