### PR TITLE
Added Xfail NNCF actions for MobileNet model

### DIFF
--- a/tests/expected_metrics/metrics_test_ote_training.yml
+++ b/tests/expected_metrics/metrics_test_ote_training.yml
@@ -45,7 +45,7 @@
 
 'ACTION-training_evaluation,model-Custom_Image_Classification_MobileNet-V3-large-1x,dataset-lg_chem,num_epochs-CONFIG,batch-CONFIG,usecase-reallife':
         'metrics.accuracy.Accuracy':
-                'target_value': 0.89
+                'target_value': 0.91
                 'max_diff_if_less_threshold': 0.005
                 'max_diff_if_greater_threshold': 0.03
 'ACTION-export_evaluation,model-Custom_Image_Classification_MobileNet-V3-large-1x,dataset-lg_chem,num_epochs-CONFIG,batch-CONFIG,usecase-reallife':

--- a/tests/test_ote_training.py
+++ b/tests/test_ote_training.py
@@ -353,6 +353,7 @@ class TestOTEReallifeClassification(OTETrainingTestInterface):
              test_parameters,
              test_case_fx, data_collector_fx,
              cur_test_expected_metrics_callback_fx):
+        # TODO(pfinashx): remove after fixing loading aux weights in NNCF
         if "MobileNet" in test_parameters['model_name'] and "nncf" in test_parameters['test_stage']:
             pytest.xfail("The MobileNet model requires loading aux weights for NNCF")
         test_case_fx.run_stage(test_parameters['test_stage'], data_collector_fx,

--- a/tests/test_ote_training.py
+++ b/tests/test_ote_training.py
@@ -353,5 +353,7 @@ class TestOTEReallifeClassification(OTETrainingTestInterface):
              test_parameters,
              test_case_fx, data_collector_fx,
              cur_test_expected_metrics_callback_fx):
+        if "MobileNet" in test_parameters['model_name'] and "nncf" in test_parameters['test_stage']:
+            pytest.xfail("The MobileNet model requires loading aux weights for NNCF")
         test_case_fx.run_stage(test_parameters['test_stage'], data_collector_fx,
                                cur_test_expected_metrics_callback_fx)


### PR DESCRIPTION

The MobileNet model requires loading aux weights for NNCF, so test actions with nncf marked as Xfail, until problem will be resolved. 
Also slightly increased target result for MobileNet model and LG-Chem dataset
Please see test build 622