### PR TITLE
Switch model templates to FP16

### DIFF
--- a/configs/ote_custom_classification/efficientnet_b0/compression_config.json
+++ b/configs/ote_custom_classification/efficientnet_b0/compression_config.json
@@ -13,7 +13,8 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            }
+            },
+            "mix_precision": false
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/efficientnet_b0/compression_config.json
+++ b/configs/ote_custom_classification/efficientnet_b0/compression_config.json
@@ -13,8 +13,7 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            },
-            "mix_precision": false
+            }
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/efficientnet_b0/main_model.yaml
+++ b/configs/ote_custom_classification/efficientnet_b0/main_model.yaml
@@ -83,7 +83,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.999
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/efficientnet_b0/main_model_multilabel.yaml
+++ b/configs/ote_custom_classification/efficientnet_b0/main_model_multilabel.yaml
@@ -83,7 +83,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.9995
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/efficientnet_v2_s/compression_config.json
+++ b/configs/ote_custom_classification/efficientnet_v2_s/compression_config.json
@@ -13,7 +13,8 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            }
+            },
+            "mix_precision": false
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/efficientnet_v2_s/compression_config.json
+++ b/configs/ote_custom_classification/efficientnet_v2_s/compression_config.json
@@ -13,8 +13,7 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            },
-            "mix_precision": false
+            }
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/efficientnet_v2_s/main_model.yaml
+++ b/configs/ote_custom_classification/efficientnet_v2_s/main_model.yaml
@@ -82,7 +82,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.999
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/efficientnet_v2_s/main_model_multilabel.yaml
+++ b/configs/ote_custom_classification/efficientnet_v2_s/main_model_multilabel.yaml
@@ -82,7 +82,7 @@ train:
   sam:
     rho: 0.05
     adaptive: False
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 64

--- a/configs/ote_custom_classification/mobilenet_v3_large_075/aux_model.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_large_075/aux_model.yaml
@@ -36,7 +36,6 @@ train:
   gamma: 0.1
   sam:
     rho: 0.15
-  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/mobilenet_v3_large_075/compression_config.json
+++ b/configs/ote_custom_classification/mobilenet_v3_large_075/compression_config.json
@@ -13,7 +13,8 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            }
+            },
+            "mix_precision": false
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/mobilenet_v3_large_075/compression_config.json
+++ b/configs/ote_custom_classification/mobilenet_v3_large_075/compression_config.json
@@ -13,8 +13,7 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            },
-            "mix_precision": false
+            }
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/mobilenet_v3_large_075/main_model.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_large_075/main_model.yaml
@@ -84,7 +84,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.999
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/mobilenet_v3_large_075/main_model_multilabel.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_large_075/main_model_multilabel.yaml
@@ -83,7 +83,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.9995
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/mobilenet_v3_large_1/aux_model.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_large_1/aux_model.yaml
@@ -36,7 +36,6 @@ train:
   gamma: 0.1
   sam:
     rho: 0.2
-  mix_precision: False
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/mobilenet_v3_large_1/compression_config.json
+++ b/configs/ote_custom_classification/mobilenet_v3_large_1/compression_config.json
@@ -13,7 +13,8 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            }
+            },
+            "mix_precision": false
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/mobilenet_v3_large_1/compression_config.json
+++ b/configs/ote_custom_classification/mobilenet_v3_large_1/compression_config.json
@@ -13,8 +13,7 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            },
-            "mix_precision": false
+            }
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/mobilenet_v3_large_1/main_model.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_large_1/main_model.yaml
@@ -84,7 +84,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.999
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/mobilenet_v3_small/aux_model.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_small/aux_model.yaml
@@ -36,7 +36,6 @@ train:
   gamma: 0.1
   sam:
     rho: 0.07
-  mix_precision: False
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/mobilenet_v3_small/compression_config.json
+++ b/configs/ote_custom_classification/mobilenet_v3_small/compression_config.json
@@ -13,7 +13,8 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            }
+            },
+            "mix_precision": false
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/mobilenet_v3_small/compression_config.json
+++ b/configs/ote_custom_classification/mobilenet_v3_small/compression_config.json
@@ -13,8 +13,7 @@
             "batch_size": 64,
             "ema": {
                 "enable": false
-            },
-            "mix_precision": false
+            }
         },
         "test": {
             "batch_size": 64

--- a/configs/ote_custom_classification/mobilenet_v3_small/main_model.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_small/main_model.yaml
@@ -83,7 +83,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.999
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/configs/ote_custom_classification/mobilenet_v3_small/main_model_multilabel.yaml
+++ b/configs/ote_custom_classification/mobilenet_v3_small/main_model_multilabel.yaml
@@ -81,7 +81,7 @@ train:
   ema:
     enable: True
     ema_decay: 0.9995
-  mix_precision: False
+  mix_precision: True
 
 test:
   batch_size: 128

--- a/tests/expected_metrics/metrics_test_ote_training.yml
+++ b/tests/expected_metrics/metrics_test_ote_training.yml
@@ -45,7 +45,7 @@
 
 'ACTION-training_evaluation,model-Custom_Image_Classification_MobileNet-V3-large-1x,dataset-lg_chem,num_epochs-CONFIG,batch-CONFIG,usecase-reallife':
         'metrics.accuracy.Accuracy':
-                'target_value': 0.91
+                'target_value': 0.95
                 'max_diff_if_less_threshold': 0.005
                 'max_diff_if_greater_threshold': 0.03
 'ACTION-export_evaluation,model-Custom_Image_Classification_MobileNet-V3-large-1x,dataset-lg_chem,num_epochs-CONFIG,batch-CONFIG,usecase-reallife':

--- a/tests/expected_metrics/metrics_test_ote_training.yml
+++ b/tests/expected_metrics/metrics_test_ote_training.yml
@@ -45,7 +45,7 @@
 
 'ACTION-training_evaluation,model-Custom_Image_Classification_MobileNet-V3-large-1x,dataset-lg_chem,num_epochs-CONFIG,batch-CONFIG,usecase-reallife':
         'metrics.accuracy.Accuracy':
-                'target_value': 0.95
+                'target_value': 0.98
                 'max_diff_if_less_threshold': 0.005
                 'max_diff_if_greater_threshold': 0.03
 'ACTION-export_evaluation,model-Custom_Image_Classification_MobileNet-V3-large-1x,dataset-lg_chem,num_epochs-CONFIG,batch-CONFIG,usecase-reallife':

--- a/torchreid/apis/training.py
+++ b/torchreid/apis/training.py
@@ -89,6 +89,9 @@ def run_training(cfg, datamanager, model, optimizer, scheduler, extra_device_ids
                                                                                  extra_device_ids,
                                                                                  aux_pretrained_dicts,
                                                                                  nncf_aux_config_changes):
+            if aux_config_opts is None:
+                aux_config_opts = []
+            aux_config_opts.extend(['train.mix_precision', cfg.train.mix_precision])
             aux_model, aux_optimizer, aux_scheduler = build_auxiliary_model(
                 config_file, num_train_classes, cfg.use_gpu, device_ids, num_iter=datamanager.num_iter,
                 lr=init_lr, nncf_aux_config_changes=nncf_config_changes,

--- a/torchreid/integration/sc/nncf_task.py
+++ b/torchreid/integration/sc/nncf_task.py
@@ -40,7 +40,7 @@ from torchreid.integration.sc.inference_task import OTEClassificationInferenceTa
 from torchreid.integration.sc.monitors import DefaultMetricsMonitor
 from torchreid.integration.sc.utils import OTEClassificationDataset, TrainingProgressCallback
 from torchreid.ops import DataParallel
-from torchreid.utils import set_random_seed
+from torchreid.utils import set_random_seed, set_model_attr
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +77,7 @@ class OTEClassificationNNCFTask(OTEClassificationInferenceTask, IOptimizationTas
         # Set default model attributes.
         self._optimization_type = ModelOptimizationType.NNCF
         logger.info('OTEClassificationNNCFTask initialization completed')
+        set_model_attr(self._model, 'mix_precision', self._cfg.train.mix_precision)
 
     @property
     def _initial_lr(self):

--- a/torchreid/integration/sc/nncf_task.py
+++ b/torchreid/integration/sc/nncf_task.py
@@ -40,7 +40,7 @@ from torchreid.integration.sc.inference_task import OTEClassificationInferenceTa
 from torchreid.integration.sc.monitors import DefaultMetricsMonitor
 from torchreid.integration.sc.utils import OTEClassificationDataset, TrainingProgressCallback
 from torchreid.ops import DataParallel
-from torchreid.utils import set_random_seed, set_model_attr
+from torchreid.utils import set_random_seed
 
 logger = logging.getLogger(__name__)
 
@@ -65,11 +65,6 @@ class OTEClassificationNNCFTask(OTEClassificationInferenceTask, IOptimizationTas
         if not self._cfg.nncf.nncf_config_path:
             self._cfg.nncf.nncf_config_path = os.path.join(self._base_dir, 'compression_config.json')
         self._cfg = patch_config(self._cfg, self._nncf_preset, self._max_acc_drop)
-        # TODO: investigate nncf compatibility with FP16
-        if self._cfg.train.mix_precision:
-            self._cfg.train.mix_precision = False
-            set_model_attr(self._model, 'mix_precision', False)
-
 
         self._compression_ctrl = None
         self._nncf_metainfo = None

--- a/torchreid/integration/sc/nncf_task.py
+++ b/torchreid/integration/sc/nncf_task.py
@@ -40,7 +40,7 @@ from torchreid.integration.sc.inference_task import OTEClassificationInferenceTa
 from torchreid.integration.sc.monitors import DefaultMetricsMonitor
 from torchreid.integration.sc.utils import OTEClassificationDataset, TrainingProgressCallback
 from torchreid.ops import DataParallel
-from torchreid.utils import set_random_seed
+from torchreid.utils import set_random_seed, set_model_attr
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,11 @@ class OTEClassificationNNCFTask(OTEClassificationInferenceTask, IOptimizationTas
         if not self._cfg.nncf.nncf_config_path:
             self._cfg.nncf.nncf_config_path = os.path.join(self._base_dir, 'compression_config.json')
         self._cfg = patch_config(self._cfg, self._nncf_preset, self._max_acc_drop)
+        # TODO: investigate nncf compatibility with FP16
+        if self._cfg.train.mix_precision:
+            self._cfg.train.mix_precision = False
+            set_model_attr(self._model, 'mix_precision', False)
+
 
         self._compression_ctrl = None
         self._nncf_metainfo = None

--- a/torchreid/utils/tools.py
+++ b/torchreid/utils/tools.py
@@ -29,7 +29,7 @@ from PIL import Image
 __all__ = [
     'mkdir_if_missing', 'check_isfile', 'read_json', 'write_json', 'read_yaml',
     'set_random_seed', "worker_init_fn", 'download_url', 'read_image', 'collect_env_info',
-    'get_model_attr', 'StateCacher', 'random_image'
+    'get_model_attr', 'StateCacher', 'random_image', 'set_model_attr'
 ]
 
 
@@ -162,10 +162,19 @@ def collect_env_info():
 
 def get_model_attr(model, attr):
     if hasattr(model, 'module'):
-        model = model.module
+        return getattr(model.module, attr)
     if hasattr(model, 'nncf_module'):
         return getattr(model.nncf_module, attr)
     return getattr(model, attr)
+
+
+def set_model_attr(model, attr, value):
+    if hasattr(model, 'module'):
+        setattr(model.module, attr, value)
+    elif hasattr(model, 'nncf_module'):
+        setattr(model.nncf_module, attr, value)
+    else:
+        setattr(model, attr, value)
 
 
 class StateCacher(object):

--- a/torchreid/utils/tools.py
+++ b/torchreid/utils/tools.py
@@ -162,7 +162,7 @@ def collect_env_info():
 
 def get_model_attr(model, attr):
     if hasattr(model, 'module'):
-        return getattr(model.module, attr)
+        model = model.module
     if hasattr(model, 'nncf_module'):
         return getattr(model.nncf_module, attr)
     return getattr(model, attr)
@@ -170,11 +170,10 @@ def get_model_attr(model, attr):
 
 def set_model_attr(model, attr, value):
     if hasattr(model, 'module'):
-        setattr(model.module, attr, value)
-    elif hasattr(model, 'nncf_module'):
+        model = model.module
+    if hasattr(model, 'nncf_module'):
         setattr(model.nncf_module, attr, value)
-    else:
-        setattr(model, attr, value)
+    setattr(model, attr, value)
 
 
 class StateCacher(object):


### PR DESCRIPTION
Note: now precision for aux models is taken from the main mode's config. NNCF task operates in FP32.