### PR TITLE
bugfix and save initial best weight if test before train is enabled

### DIFF
--- a/scripts/default_config.py
+++ b/scripts/default_config.py
@@ -211,6 +211,7 @@ def get_default_config():
     cfg.test.eval_freq = -1  # evaluation frequency (-1 means to only test after training)
     cfg.test.start_eval = 0  # start to evaluate after a specific epoch
     cfg.test.test_before_train = False
+    cfg.test.save_initial_metric = False
     cfg.test.estimate_multilabel_thresholds = False
 
     # Augmentations

--- a/torchreid/apis/training.py
+++ b/torchreid/apis/training.py
@@ -25,8 +25,7 @@ from torchreid.integration.nncf.engine import run_acc_aware_training_loop
 from torchreid.optim import LrFinder
 from scripts.default_config import (lr_finder_run_kwargs,
                                     lr_scheduler_kwargs, model_kwargs,
-                                    optimizer_kwargs, engine_run_kwargs,
-                                    engine_test_kwargs)
+                                    optimizer_kwargs, engine_run_kwargs)
 from torchreid.utils import set_random_seed
 from scripts.script_utils import (build_datamanager, build_auxiliary_model,
                                   put_main_model_on_the_device)

--- a/torchreid/apis/training.py
+++ b/torchreid/apis/training.py
@@ -17,6 +17,7 @@
 import sys
 from copy import deepcopy
 import shutil
+from os import path as osp
 
 import torchreid
 from torchreid.engine import build_engine
@@ -114,20 +115,24 @@ def run_training(cfg, datamanager, model, optimizer, scheduler, extra_device_ids
 
     accuracy = None
     final_accuracy = None
-    if cfg.test.test_before_train or cfg.test.evaluate:
+    if (cfg.test.test_before_train or
+        cfg.test.evaluate or
+        cfg.test.save_initial_metric):
         if cfg.test.test_before_train:
             print('Test before training')
         accuracy = engine.test(0, test_only=True)[0]
         if cfg.test.evaluate:
             return accuracy, None
 
-        model_weight_file = None
-        if cfg.model.resume:
-            model_weight_file = cfg.model.resume
-        elif cfg.model.load_weights:
-            model_weight_file = cfg.model.load_weights
-        if model_weight_file is not None:
-            shutil.copy(model_weight_file, f"{cfg.data.save_dir}/best.pth")
+        if cfg.test.save_initial_metric:
+            model_weight_file = None
+            if cfg.model.resume:
+                model_weight_file = cfg.model.resume
+            elif cfg.model.load_weights:
+                model_weight_file = cfg.model.load_weights
+            if model_weight_file is not None:
+                shutil.copy(model_weight_file,
+                    osp.join(cfg.data.save_dir, "best.pth"))
             engine.best_metric = accuracy
 
     nncf_config = cfg.get('nncf_config')


### PR DESCRIPTION
This PR contains a bugfix and saving initial weight if resume or load is executed and test before train is done.
Modification at "engine.test()" is a bugfix.
engine_test_kwargs(cfg) return wrong value, so it's deleted.
Other line modification are for saving initial weight.