### PR TITLE
bugfixes related to nncf cfg and aux model cfg

### DIFF
--- a/tools/main.py
+++ b/tools/main.py
@@ -133,6 +133,7 @@ def main():
     log_dir = cfg.data.tb_log_dir if cfg.data.tb_log_dir else cfg.data.save_dir
     run_training(cfg, datamanager, model, optimizer, scheduler, extra_device_ids,
                  aux_lr, tb_writer=SummaryWriter(log_dir=log_dir),
+                 aux_config_opts=args.aux_config_opts,
                  should_freeze_aux_models=should_freeze_aux_models,
                  nncf_metainfo=nncf_metainfo,
                  compression_ctrl=compression_ctrl)

--- a/torchreid/integration/nncf/compression_script_utils.py
+++ b/torchreid/integration/nncf/compression_script_utils.py
@@ -83,7 +83,7 @@ def make_nncf_changes_in_config(cfg,
     cfg.nncf.enable_pruning = enable_pruning
     nncf_preset = get_nncf_preset_name(enable_quantization, enable_pruning)
 
-    patch_config(cfg, nncf_preset)
+    cfg = patch_config(cfg, nncf_preset)
 
     if command_line_cfg_opts is not None:
         logger.info(f'applying changes to the main training config from the command line options just after that. '


### PR DESCRIPTION
This PR contains 2 bugfixes
- nncf_config is not updated to main cfg.
- aux_config_opts, which is to update additional cfgs through command line, is not applied when building aux model(s).