### PR TITLE
fix if order which defines output fc layer

### DIFF
--- a/torchreid/models/efficient_net_pytcv.py
+++ b/torchreid/models/efficient_net_pytcv.py
@@ -351,13 +351,13 @@ class EfficientNet(ModelInterface):
         self.output = nn.Sequential()
         if dropout_cls:
             self.output.add_module("dropout", Dropout(**dropout_cls))
-        if 'softmax' in self.loss or 'asl' in self.loss:
-            self.output.add_module("fc", nn.Linear(
+        if 'am_softmax' in self.loss or 'am_binary' in self.loss:
+            self.output.add_module("asl", AngleSimpleLinear(
                 in_features=final_block_channels,
                 out_features=self.num_classes))
         else:
-            assert 'am_softmax' in self.loss or 'am_binary' in self.loss
-            self.output.add_module("asl", AngleSimpleLinear(
+            assert 'softmax' in self.loss or 'asl' in self.loss
+            self.output.add_module("fc", nn.Linear(
                 in_features=final_block_channels,
                 out_features=self.num_classes))
 

--- a/torchreid/models/efficient_net_pytcv.py
+++ b/torchreid/models/efficient_net_pytcv.py
@@ -351,11 +351,11 @@ class EfficientNet(ModelInterface):
         self.output = nn.Sequential()
         if dropout_cls:
             self.output.add_module("dropout", Dropout(**dropout_cls))
-        if 'am_softmax' in self.loss or 'am_binary' in self.loss:
+        if 'am_softmax' == self.loss or 'am_binary' == self.loss:
             self.output.add_module("asl", AngleSimpleLinear(
                 in_features=final_block_channels,
                 out_features=self.num_classes))
-        elif 'softmax' in self.loss or 'asl' in self.loss:
+        elif 'softmax' == self.loss or 'asl' == self.loss:
             self.output.add_module("fc", nn.Linear(
                 in_features=final_block_channels,
                 out_features=self.num_classes))

--- a/torchreid/models/efficient_net_pytcv.py
+++ b/torchreid/models/efficient_net_pytcv.py
@@ -355,11 +355,12 @@ class EfficientNet(ModelInterface):
             self.output.add_module("asl", AngleSimpleLinear(
                 in_features=final_block_channels,
                 out_features=self.num_classes))
-        else:
-            assert 'softmax' in self.loss or 'asl' in self.loss
+        elif 'softmax' in self.loss or 'asl' in self.loss:
             self.output.add_module("fc", nn.Linear(
                 in_features=final_block_channels,
                 out_features=self.num_classes))
+        else:
+            raise ValueError(f"self.loss={self.loss} is unknown loss type.")
 
         self._init_params()
 


### PR DESCRIPTION
This PR contains a bugfix about the model with AngleSimpleLinear is not loaded even though self.loss is set to 'am_softmax'.