### PR TITLE
Enable nncf for multihead classification

### DIFF
--- a/torchreid/engine/builder.py
+++ b/torchreid/engine/builder.py
@@ -4,7 +4,7 @@
 
 from .image import (ImageAMSoftmaxEngine, MultilabelEngine, MultiheadEngine)
 
-NNCF_ENABLED_LOSS = ['softmax', 'am_softmax', 'am_binary']
+NNCF_ENABLED_LOSS = ['softmax', 'am_softmax', 'am_binary', 'asl']
 
 def build_engine(cfg, datamanager, model, optimizer, scheduler,
                  should_freeze_aux_models=False,
@@ -12,7 +12,7 @@ def build_engine(cfg, datamanager, model, optimizer, scheduler,
                  compression_ctrl=None,
                  initial_lr=None):
     if should_freeze_aux_models or nncf_metainfo:
-        if not any(loss_name in NNCF_ENABLED_LOSS for loss_name in cfg.loss.name.split(',')):
+        if not all(loss_name in NNCF_ENABLED_LOSS for loss_name in cfg.loss.name.split(',')):
             raise NotImplementedError('Freezing of aux models or NNCF compression are supported only for '
                                       'softmax, am_softmax and am_binary losses for data.type = image')
     initial_lr = initial_lr if initial_lr else cfg.train.lr

--- a/torchreid/engine/builder.py
+++ b/torchreid/engine/builder.py
@@ -4,17 +4,17 @@
 
 from .image import (ImageAMSoftmaxEngine, MultilabelEngine, MultiheadEngine)
 
+NNCF_ENABLED_LOSS = ['softmax', 'am_softmax', 'am_binary']
 
 def build_engine(cfg, datamanager, model, optimizer, scheduler,
                  should_freeze_aux_models=False,
                  nncf_metainfo=None,
                  compression_ctrl=None,
                  initial_lr=None):
-    # TODO : Align with multihead to comment in below codes
-    # if should_freeze_aux_models or nncf_metainfo:
-    #     if cfg.loss.name not in ['softmax', 'am_softmax', 'am_binary']:
-    #         raise NotImplementedError('Freezing of aux models or NNCF compression are supported only for '
-    #                                   'softmax, am_softmax and am_binary losses for data.type = image')
+    if should_freeze_aux_models or nncf_metainfo:
+        if not any(loss_name in NNCF_ENABLED_LOSS for loss_name in cfg.loss.name.split(',')):
+            raise NotImplementedError('Freezing of aux models or NNCF compression are supported only for '
+                                      'softmax, am_softmax and am_binary losses for data.type = image')
     initial_lr = initial_lr if initial_lr else cfg.train.lr
     classification_params = dict(
             datamanager=datamanager,

--- a/torchreid/engine/builder.py
+++ b/torchreid/engine/builder.py
@@ -10,10 +10,11 @@ def build_engine(cfg, datamanager, model, optimizer, scheduler,
                  nncf_metainfo=None,
                  compression_ctrl=None,
                  initial_lr=None):
-    if should_freeze_aux_models or nncf_metainfo:
-        if cfg.loss.name not in ['softmax', 'am_softmax', 'am_binary']:
-            raise NotImplementedError('Freezing of aux models or NNCF compression are supported only for '
-                                      'softmax, am_softmax and am_binary losses for data.type = image')
+    # TODO : Align with multihead to comment in below codes
+    # if should_freeze_aux_models or nncf_metainfo:
+    #     if cfg.loss.name not in ['softmax', 'am_softmax', 'am_binary']:
+    #         raise NotImplementedError('Freezing of aux models or NNCF compression are supported only for '
+    #                                   'softmax, am_softmax and am_binary losses for data.type = image')
     initial_lr = initial_lr if initial_lr else cfg.train.lr
     classification_params = dict(
             datamanager=datamanager,

--- a/torchreid/integration/nncf/compression.py
+++ b/torchreid/integration/nncf/compression.py
@@ -22,7 +22,7 @@ from pprint import pformat
 import logging
 import torch
 
-from torchreid.metrics import evaluate_multilabel_classification
+from torchreid.metrics import evaluate_multilabel_classification, evaluate_multihead_classification
 from torchreid.utils import get_model_attr
 from torchreid.utils.tools import random_image
 
@@ -177,6 +177,7 @@ def register_custom_modules():
 
 
 def wrap_nncf_model(model, cfg,
+                    multihead_info=None,
                     checkpoint_dict=None,
                     datamanager_for_init=None):
     # Note that we require to import it here to avoid cyclic imports when import get_no_nncf_trace_context_manager
@@ -279,6 +280,14 @@ def wrap_nncf_model(model, cfg,
                 use_gpu=use_gpu
             )
             accuracy = mAP
+        elif model_type == 'multihead':
+            mhacc, _, _ = evaluate_multihead_classification(
+                test_loader,
+                model,
+                use_gpu,
+                multihead_info
+            )
+            accuracy = mhacc
         else:
             raise ValueError(f'Cannot perform a model evaluation on the validation dataset'
                                 f'since the model has unsupported model_type {model_type or "None"}')


### PR DESCRIPTION
Apply nncf to multihead classification in the evaluation of the model.
