### PR TITLE
Update openvino reqs

### DIFF
--- a/openvino-requirements.txt
+++ b/openvino-requirements.txt
@@ -1,4 +1,4 @@
 openvino==2022.2.0
 openvino-dev==2022.2.0
-git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2021/SCMVP#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
+openmodelzoo-modelapi@git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2022/SCv1.1#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 nncf@git+https://github.com/openvinotoolkit/nncf@e85a695da95b202b4579ea11f880f1b14bfcda2e#egg=nncf

--- a/openvino-requirements.txt
+++ b/openvino-requirements.txt
@@ -1,4 +1,4 @@
-openvino==2022.1.0
-openvino-dev==2022.1.0
+openvino==2022.2.0
+openvino-dev==2022.2.0
 git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2021/SCMVP#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 nncf@git+https://github.com/openvinotoolkit/nncf@e85a695da95b202b4579ea11f880f1b14bfcda2e#egg=nncf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 Pillow
 six
-scipy==1.8.1
+scipy==1.8.0
 opencv-python
 matplotlib
 tb-nightly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 Pillow
 six
-scipy==1.8.0
+scipy==1.5.4
 opencv-python
 matplotlib
 tb-nightly
@@ -15,7 +15,7 @@ torch-lr-finder==0.2.1
 onnx
 torchvision==0.9.*
 torch==1.8.*
-optuna
+optuna==2.10.1
 timm>=0.6.5
 addict
 randaugment


### PR DESCRIPTION
Openvino requires scipy==1.5.4, while optuna 3.0 requires 1.8+. This PR downgrades both the components to avoid deps conflicts.